### PR TITLE
Adjust runtests so it can be invoked anywhere

### DIFF
--- a/runtests
+++ b/runtests
@@ -3,7 +3,7 @@ set -u
 set -e
 
 # runtests: wrapper script to invoke ctf-cli.py
-# usage: ./ce-ctf-tests/runtests <image name> <path to feature file>
+# usage: runtests <image name> <path to feature file>
 #
 # this script presumes we want to test an already-built image using
 # features described in a single feature file. It hides the details
@@ -34,19 +34,34 @@ docker inspect "$image" >/dev/null # valid image?
 [ -f "$testf" ] || die "Not a feature file: $testf"
 [ -f "$cli" ] || die "$cli does not exist. You can override this path by defining the 'cli' environment variable."
 
-# set up testing environment
-[ -d tests ] || {
-  [ -d ce-ctf-tests ] || die "ce-ctf-tests is not a checkout of the ce-ctf-tests repo"
-  cp -a ce-ctf-tests/tests tests
+# find the root of the jboss-dockerfiles repository (needed for ../tools/ci/ctf.conf)
+# XXX: assumes that the test file is in that directory somewhere, which it might not be
+pushd $(dirname "$testf") >/dev/null
+repo="$(git rev-parse --show-toplevel)"
+popd >/dev/null
+
+# working directory
+workdir=$(mktemp -td runtests_XXXXXX)
+cleanup() {
+    if [ -n "$workdir" ]; then
+        rm -r "$workdir"
+    fi
 }
-[ -d tests/features ] || mkdir tests/features
+trap cleanup EXIT
+
+# set up testing environment
+# XXX: assumes ce-ctf-tests is in jboss-dockerfiles repo. Could be anywhere.
+if [ -d "$repo/ce-ctf-tests" ]; then
+  cp -a "$repo/ce-ctf-tests/tests" "$workdir/tests"
+else
+  die "couldn't find ce-ctf-tests (tried $repo/ce-ctf-tests)"
+fi
+mkdir -p "$workdir/tests/features"
 
 # set up tests
-for f in tests/features/*.feature; do
-    [ -f "$f" ] && echo "warning: feature file '$f' exists and will be included."
-done
-dest="tests/features/$(basename "$testf")"
+dest="$workdir/tests/features/$(basename "$testf")"
 cp "$testf" "$dest"
 
-"$cli" -v -i "$image" -c tools/ci/ctf.conf \
+cd "$workdir"
+"$cli" -v -i "$image" -c "$repo/tools/ci/ctf.conf" \
     -f /dev/null # hack to get around specifying a Dockerfile, thanks Marek


### PR DESCRIPTION
No dependency on being in the root of the jboss-dockerfiles checkout
anymore.

Attempts to guess location of jboss-dockerfiles repo based on the
feature file supplied.

Presumes ce-ctf-tests is checked out *within* jboss-dockerfiles, as
the previous version of the script did, an as the instruction say to
do. (We will want to change this soon)

Work in a temporary directory and remove it after invocation.